### PR TITLE
Update mpr-nanossl.c

### DIFF
--- a/mpr-nanossl.c
+++ b/mpr-nanossl.c
@@ -274,9 +274,9 @@ static void manageNanoSocket(NanoSocket *np, int flags)
         mprMark(np->sock);
 
     } else if (flags & MPR_MANAGE_FREE) {
-        if (np->handle) {
+        if (np->handle >= 0) {
             SSL_closeConnection(np->handle);
-            np->handle = 0;
+            np->handle = -1;
         }
     }
 }
@@ -289,9 +289,9 @@ static void nanoClose(MprSocket *sp, bool gracefully)
     np = sp->sslSocket;
     lock(sp);
     sp->service->standardProvider->closeSocket(sp, gracefully);
-    if (np->handle) {
+    if (np->handle >= 0) {
         SSL_closeConnection(np->handle);
-        np->handle = 0;
+        np->handle = -1;
     }
     unlock(sp);
 }
@@ -316,6 +316,7 @@ static int nanoUpgrade(MprSocket *sp, MprSsl *ssl, cchar *peerName)
         return MPR_ERR_MEMORY;
     }
     np->sock = sp;
+    np->handle = -1;
     sp->sslSocket = np;
     sp->ssl = ssl;
 


### PR DESCRIPTION
connectionInstance received from SSL_acceptConnection can be >=0. So 0 is also a valid value and should be closed.